### PR TITLE
Use optional flag for list field instead of the item

### DIFF
--- a/src/hodur_lacinia_schema/core.clj
+++ b/src/hodur_lacinia_schema/core.clj
@@ -21,16 +21,22 @@
     (->PascalCaseKeyword name)
     (get primitive-type-map name)))
 
+(defn ^:private cardinality-one-to-one? [cardinality]
+  (and (= (first cardinality) 1)
+       (or (nil? (second cardinality))
+           (= (second cardinality) 1))))
+
 (defn ^:private get-full-type [type optional cardinality]
-  (let [inner-type (if optional
+  (let [non-null-inner-type (list 'non-null (get-type-reference type))
+        list-type (list 'list non-null-inner-type)
+        inner-type (if optional
                      (get-type-reference type)
-                     (list 'non-null (get-type-reference type)))]
-    (if cardinality
-      (if (and (= (first cardinality) 1)
-               (or (nil? (second cardinality))
-                   (= (second cardinality) 1)))
-        inner-type
-        (list 'list inner-type))
+                     non-null-inner-type)]
+    (if (and (some? cardinality)
+             (not (cardinality-one-to-one? cardinality)))
+      (if optional
+        list-type
+        (list 'non-null list-type))
       inner-type)))
 
 (defn ^:private get-field-type
@@ -318,5 +324,5 @@
 
     (def s (schema conn))
 
-    s
-    ))
+    s))
+

--- a/test/core_test.clj
+++ b/test/core_test.clj
@@ -38,7 +38,7 @@
               {:fields
                {:id {:type (non-null ID)}
                 :name {:type (non-null String)}
-                :relations {:type (list :Relation)}}}
+                :relations {:type (list (non-null :Relation))}}}
               :Relation
               {:fields
                {:type {:type (non-null :RelationType)}
@@ -85,7 +85,7 @@
               {:type (non-null :Person)
                :args {:id {:type (non-null ID)}}}
               :searchPersons
-              {:type (list (non-null :Person))
+              {:type (non-null (list (non-null :Person)))
                :args {:term {:type String
                              :default-value ""}}}}}
            s))))
@@ -125,9 +125,9 @@
                :resolve :query/person-by-id
                :args {:id {:type (non-null ID)}}}
               :peopleByIds
-              {:type (list (non-null :Person))
+              {:type (non-null (list (non-null :Person)))
                :resolve :query/people-by-ids
-               :args {:ids {:type (list (non-null ID))}}}}}
+               :args {:ids {:type (non-null (list (non-null ID)))}}}}}
            s))))
 
 ;; Tests:


### PR DESCRIPTION
Instead using the optional flag to set list item as optional, use it as a flag for the list field itself. Since there isn't a way to specify the list item optionality, it will be enforced as non-null.